### PR TITLE
last demo cleanup tweak: hole to winners room from one_lesson

### DIFF
--- a/one_activity.js
+++ b/one_activity.js
@@ -421,6 +421,7 @@ class one_activity extends Phaser.Scene {
           this.actOne_E_KeyImg.alpha = 1.0;
 
           if(this.actOne_key_E.isDown) {
+	      roomProgress = 35;
             this.scene.start("one_Lesson");
           }
         }

--- a/one_lesson.js
+++ b/one_lesson.js
@@ -67,7 +67,9 @@ class one_lesson extends Phaser.Scene {
       this.checkNextPage();
     }
 
-    if(this.room3_activity5Complete == true) {
+    if(this.room3_activity5Complete == true || roomProgress == 35) {
+	this.room3_activity5Complete = true;
+	roomProgress = 35;
       this.room3_hole.alpha = 1.0;
     }
 


### PR DESCRIPTION
Coming out of one_activity (accnting equation) back into one_lesson (third room; red/black floor) the winner room hole was not visible.
