### PR TITLE
added roomProgress variable to keep track of progress

### DIFF
--- a/accountEqn.js
+++ b/accountEqn.js
@@ -11,12 +11,6 @@ class accountEqn extends Phaser.Scene {
     this.room3_activityThreeOpened = false;
     this.room3_activityFourOpened = false;
     this.room3_activityFiveOpened = false;
-    this.room3_activity1Locked = false;
-    this.room3_activity2Locked = true;
-    this.room3_activity3Locked = true;
-    this.room3_activity4Locked = true;
-    this.room3_activity5Locked = true;
-    this.room3_activity5Complete = false;
     this.room3_helpOpen = false;
     this.room3_counter = 0;
   }
@@ -65,20 +59,14 @@ class accountEqn extends Phaser.Scene {
       this.checkNextPage();
     }
 
-    if(this.room3_activity5Complete == true || roomProgress == 35) {
-	this.room3_activity5Complete = true;
-	roomProgress = 35;
+    if(roomProgress >= 3025 && this.room3_unlocked) {
       this.room3_hole.alpha = 1.0;
     }
 
 
-    if (this.room3_key_U.isDown && this.room3_unlocked == false) {
-      this.room3_activity1Locked = false;
-      this.room3_activity2Locked = false;
-      this.room3_activity3Locked = false;
-      this.room3_activity4Locked = false;
-      this.room3_activity5Locked = false;
-      this.room3_activity5Complete = true;
+    if (this.room3_key_U.isDown) {
+      roomProgress = 3025;
+      this.room3_hole.alpha = 1.0;
       this.room3_unlocked = true;
     }
 
@@ -141,7 +129,6 @@ class accountEqn extends Phaser.Scene {
     this.load.image('room3_character_east', 'assets/character_east.png');
     this.load.image('room3_character_south', 'assets/character_south.png');
     this.load.image('room3_character_west', 'assets/character_west.png');
-    this.load.image('room3_redCharacter', 'assets/redCharacter.png');
     this.load.image('room3_activity1A', 'assets/Panels/RoomThree/PanelOneA.png');
     this.load.image('room3_activity1B', 'assets/Panels/RoomThree/PanelOneB.png');
     this.load.image('room3_activity1C', 'assets/Panels/RoomThree/PanelOneC.png');
@@ -395,12 +382,15 @@ class accountEqn extends Phaser.Scene {
       this.room3_E_KeyImg.x = this.room3_character_north.x;
       this.room3_E_KeyImg.y = this.room3_character_north.y-75;
       this.room3_E_KeyImg.alpha = 1.0;
+      
       if (this.room3_key_E.isDown) {
+        if(roomProgress <= 3000)
+          roomProgress = 3005;
+        
         this.room3_activity1A.alpha = 1.0;
         this.resetArrows();
         this.room3_characterMoveable = false;
         this.checkActivityOpened(true, false, false, false, false, false);
-    this.room3_activity2Locked = false;
 
     //COME BACK AND CHANGE THIS LATER
       }
@@ -409,26 +399,35 @@ class accountEqn extends Phaser.Scene {
       this.room3_E_KeyImg.x = this.room3_character_north.x;
       this.room3_E_KeyImg.y = this.room3_character_north.y+75;
       this.room3_E_KeyImg.alpha = 1.0;
-    if (this.room3_key_E.isDown && this.room3_activity2Locked == false) {
+      console.log(roomProgress);
+      
+      if (this.room3_key_E.isDown && roomProgress >= 3005) {
+        if(roomProgress <= 3010)
+          roomProgress = 3010;
+
         this.room3_activity2A.alpha = 1.0;
         this.resetArrows();
         this.checkActivityOpened(false, true, false, false, false, false);
-    this.room3_activity3Locked = false;
-  } else if (this.room3_key_E.isDown && this.room3_activity2Locked == true) {
+  } else if (this.room3_key_E.isDown && roomProgress < 3005) {
           this.room3_activityLocked.alpha = 1.0;
           this.room3_characterMoveable = false;
-          }
+    }
 
     } else if (Phaser.Geom.Rectangle.ContainsPoint(this.room3_top_left_info, this.room3_character_north)) {
       this.room3_E_KeyImg.x = this.room3_character_north.x;
       this.room3_E_KeyImg.y = this.room3_character_north.y-75;
       this.room3_E_KeyImg.alpha = 1.0;
-      if (this.room3_key_E.isDown && this.room3_activity3Locked == false) {
+      
+      if (this.room3_key_E.isDown && roomProgress >= 3010) {
+        if(roomProgress <= 3015)
+          roomProgress = 3015;
+
         this.room3_activity3A.alpha = 1.0;
         this.resetArrows();
         this.checkActivityOpened(false, false, true, false, false, false);
         this.room3_activity4Locked = false;
-  } else if (this.room3_key_E.isDown && this.room3_activity3Locked == true){
+
+  } else if (this.room3_key_E.isDown && roomProgress < 3010){
         this.room3_activityLocked.alpha = 1.0;
         this.room3_characterMoveable = false;
         }
@@ -437,11 +436,15 @@ class accountEqn extends Phaser.Scene {
       this.room3_E_KeyImg.x = this.room3_character_north.x;
       this.room3_E_KeyImg.y = this.room3_character_north.y+75;
       this.room3_E_KeyImg.alpha = 1.0;
-      if (this.room3_key_E.isDown && this.room3_activity4Locked == false) {
-            this.scene.start("AccountEqn_Act");
-            this.checkActivityOpened(false, false, false, true, false, false);
-            this.room3_activity5Locked = false;
-  } else if (this.room3_key_E.isDown && this.room3_activity4Locked == true){
+      if (this.room3_key_E.isDown && roomProgress >= 3015) {
+        if(roomProgress <= 3020)
+            roomProgress = 3020;
+
+        this.scene.start("AccountEqn_Act");
+        this.checkActivityOpened(false, false, false, true, false, false);
+        this.room3_activity5Locked = false;
+
+  } else if (this.room3_key_E.isDown && roomProgress < 3015){
         this.room3_activityLocked.alpha = 1.0;
         this.room3_characterMoveable = false;
         }
@@ -452,24 +455,27 @@ class accountEqn extends Phaser.Scene {
 		this.room3_E_KeyImg.x = this.room3_character_north.x;
 		this.room3_E_KeyImg.y = this.room3_character_north.y-75;
     this.room3_E_KeyImg.alpha = 1.0;
-		if (this.room3_key_E.isDown && this.room3_activity5Locked == false) {
+    console.log(roomProgress);
+		if (this.room3_key_E.isDown && roomProgress >= 3020) {
+      if(roomProgress <= 3025)
+          roomProgress = 3025;
+      
 			this.room3_activity5A.alpha = 1.0;
       this.resetArrows();
 			this.checkActivityOpened(false, false, false, false, true, false);
       this.room3_unlocked = true;
-			//this.room3_activity6Locked = false;
 		}
   }
-  else if (this.room3_key_E.isDown && this.room3_activity5Locked == true){
+  else if (this.room3_key_E.isDown && roomProgress < 3020){
         this.room3_activityLocked.alpha = 1.0;
         this.room3_characterMoveable = false;
       }
 
-    else if (Phaser.Geom.Rectangle.ContainsPoint(this.room3_hole_info, this.room3_character_north) && this.room3_activity5Complete) {
+    else if (Phaser.Geom.Rectangle.ContainsPoint(this.room3_hole_info, this.room3_character_north)) {
       this.room3_E_KeyImg.x = this.room3_character_north.x;
   		this.room3_E_KeyImg.y = this.room3_character_north.y-75;
       this.room3_E_KeyImg.alpha = 1.0;
-      if (this.room3_key_E.isDown && this.room3_activity5Complete == true) {
+      if (this.room3_key_E.isDown && roomProgress >= 3025) {
         this.scene.start("winners_Room");
       }
     }

--- a/accountEqnAct.js
+++ b/accountEqnAct.js
@@ -58,18 +58,6 @@ class accountEqnAct extends Phaser.Scene {
       this.checkNextPage();
     }
 
-
-    if (this.actOne_key_U.isDown && this.actOne_unlocked == false) {
-      actOne_activity1Locked = false;
-      actOne_activity2Locked = false;
-      actOne_activity3Locked = false;
-      actOne_activity4Locked = false;
-      actOne_activity5Locked = false;
-      actOne_activity6Locked = false;
-      actOne_activity6Complete = true;
-      this.actOne_unlocked = true;
-    }
-
     if (this.actOne_key_M.isDown) {
       this.actOne_map.alpha = 1.0;
       actOne_characterMoveable = false;
@@ -379,7 +367,6 @@ class accountEqnAct extends Phaser.Scene {
           this.actOne_E_KeyImg.alpha = 1.0;
 
           if(this.actOne_key_E.isDown) {
-	      roomProgress = 35;
             this.scene.start("Account_Eqn");
           }
         }

--- a/buildingBlocks.js
+++ b/buildingBlocks.js
@@ -11,13 +11,6 @@ class buildingBlocks extends Phaser.Scene {
         this.room2_activityFourOpened = false;
         this.room2_activityFiveOpened = false;
         this.room2_activitySixOpened = false;
-        this.room2_activity1Locked = false;
-        this.room2_activity2Locked = true;
-        this.room2_activity3Locked = true;
-        this.room2_activity4Locked = true;
-        this.room2_activity5Locked = true;
-        this.room2_activity6Locked = true;
-        this.room2_activity6Complete = false;
         this.room2_helpOpen = false;
         this.counter = 0;
 
@@ -68,25 +61,15 @@ class buildingBlocks extends Phaser.Scene {
         if (this.room2_activitySixOpened) {
             this.checkNextPage();
         }
-        if (this.room2_activity6Complete == true) {
+        if (roomProgress >= 2030) {
           this.room2_hole_activity.alpha = 1.0;
           this.room2_hole_nextRoom.alpha = 1.0;
         }
 
 
         if (this.room2_key_U.isDown) {
-            this.room2_activity1Locked = false;
-            this.room2_activity2Locked = false;
-            this.room2_activity3Locked = false;
-            this.room2_activity4Locked = false;
-            this.room2_activity5Locked = false;
-            this.room2_activity6Locked = false;
-            this.room2_activity6Complete = true;
+            roomProgress = 2030;
             this.room2_unlocked = true;
-        }
-        if(this.room2_activity6Complete == true) {
-          this.room2_hole_activity.alpha = 1.0;
-          this.room2_hole_nextRoom.alpha = 1.0;
         }
 
         if (this.room2_key_M.isDown) {
@@ -428,23 +411,28 @@ class buildingBlocks extends Phaser.Scene {
             this.room2_E_KeyImg.y = this.room2_character_north.y-75;
             this.room2_E_KeyImg.alpha = 1.0;
             if (this.room2_key_E.isDown) {
+                if(roomProgress <= 2000)
+                    roomProgress = 2005;
+
                 this.room2_activity1A.alpha = 1.0;
                 this.resetArrows();
                 this.room2_characterMoveable = false;
                 this.checkActivityOpened(true, false, false, false, false, false);
-                this.room2_activity2Locked = false;
             }
 
         } else if (Phaser.Geom.Rectangle.ContainsPoint(this.room2_bot_left_info, this.room2_character_north)) {
             this.room2_E_KeyImg.x = this.room2_character_north.x;
             this.room2_E_KeyImg.y = this.room2_character_north.y+75;
             this.room2_E_KeyImg.alpha = 1.0;
-            if (this.room2_key_E.isDown && this.room2_activity2Locked == false) {
+            if (this.room2_key_E.isDown && roomProgress >= 2005) {
+                if(roomProgress <= 2010)
+                    roomProgress = 2010;
+
                 this.room2_activity2A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, true, false, false, false, false);
-                this.room2_activity3Locked = false;
-            } else if (this.room2_key_E.isDown && this.room2_activity2Locked == true) {
+            
+            } else if (this.room2_key_E.isDown && roomProgress < 2005) {
                 this.room2_activityLocked.alpha = 1.0;
                 this.room2_characterMoveable = false;
             }
@@ -453,12 +441,15 @@ class buildingBlocks extends Phaser.Scene {
             this.room2_E_KeyImg.x = this.room2_character_north.x;
             this.room2_E_KeyImg.y = this.room2_character_north.y-75;
             this.room2_E_KeyImg.alpha = 1.0;
-            if (this.room2_key_E.isDown && this.room2_activity3Locked == false) {
+            if (this.room2_key_E.isDown && roomProgress >= 2010) {
+                if(roomProgress <= 2015)
+                    roomProgress = 2015;
+
                 this.room2_activity3A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, true, false, false, false);
-                this.room2_activity4Locked = false;
-            } else if (this.room2_key_E.isDown && this.room2_activity3Locked == true){
+
+            } else if (this.room2_key_E.isDown && roomProgress < 2010){
                 this.room2_activityLocked.alpha = 1.0;
                 this.room2_characterMoveable = false;
             }
@@ -467,12 +458,15 @@ class buildingBlocks extends Phaser.Scene {
             this.room2_E_KeyImg.x = this.room2_character_north.x;
             this.room2_E_KeyImg.y = this.room2_character_north.y+75;
             this.room2_E_KeyImg.alpha = 1.0;
-            if (this.room2_key_E.isDown && this.room2_activity4Locked == false) {
+            if (this.room2_key_E.isDown && roomProgress >= 2015) {
+                if(roomProgress <= 2020)
+                    roomProgress = 2020;
+
                 this.room2_activity4A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, false, true, false, false);
-                this.room2_activity5Locked = false;
-            } else if (this.room2_key_E.isDown && this.room2_activity4Locked == true){
+
+            } else if (this.room2_key_E.isDown && roomProgress < 2015){
                 this.room2_activityLocked.alpha = 1.0;
                 this.room2_characterMoveable = false;
 
@@ -482,13 +476,15 @@ class buildingBlocks extends Phaser.Scene {
             this.room2_E_KeyImg.y = this.room2_character_north.y-75;
 
             this.room2_E_KeyImg.alpha = 1.0;
-            if (this.room2_key_E.isDown && this.room2_activity5Locked == false) {
+            if (this.room2_key_E.isDown && roomProgress >= 2020) {
+                if(roomProgress <= 2025)
+                    roomProgress = 2025;
+
                 this.room2_activity5A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, false, false, true, false);
-                this.room2_activity6Locked = false;
             }
-            else if (this.room2_key_E.isDown && this.room2_activity5Locked == true){
+            else if (this.room2_key_E.isDown && roomProgress < 2020){
                 this.room2_activityLocked.alpha = 1.0;
                 this.room2_characterMoveable = false;
             }
@@ -497,25 +493,27 @@ class buildingBlocks extends Phaser.Scene {
             this.room2_E_KeyImg.x = this.room2_character_north.x;
             this.room2_E_KeyImg.y = this.room2_character_north.y+75;
             this.room2_E_KeyImg.alpha = 1.0;
-            if (this.room2_key_E.isDown && this.room2_activity6Locked == false) {
+            if (this.room2_key_E.isDown && roomProgress >= 2025) {
+                if(roomProgress <= 2030)
+                    roomProgress = 2030;
+                console.log(roomProgress);      
                 this.room2_activity6A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, false, false, false, true);
-                this.room2_activity6Complete = true;
             }
-            else if (this.room2_key_E.isDown && this.room2_activity6Locked == true){
+            else if (this.room2_key_E.isDown && roomProgress < 2025){
                 this.room2_activityLocked.alpha = 1.0;
                 this.room2_characterMoveable = false;
             }
 
         }
         else if (Phaser.Geom.Rectangle.ContainsPoint(this.room2_hole_zone_nextRoom, this.room2_character_north)) {
-            if(this.room2_activity6Complete == true) {
+            if(roomProgress >= 2030) {
               this.room2_E_KeyImg.x = this.room2_character_north.x;
               this.room2_E_KeyImg.y = this.room2_character_north.y+75;
               this.room2_E_KeyImg.alpha = 1.0;
               if (this.room2_key_E.isDown) {
-                  console.log("To room 3")
+                  roomProgress = 3000;
                   this.scene.start("Account_Eqn");
               }
             }
@@ -524,13 +522,13 @@ class buildingBlocks extends Phaser.Scene {
         }
 
         else if (Phaser.Geom.Rectangle.ContainsPoint(this.room2_hole__zone_activity, this.room2_character_north)) {
-            if(this.room2_activity6Complete == true) {
+            if(roomProgress >= 2030) {
               this.room2_E_KeyImg.x = this.room2_character_north.x;
               this.room2_E_KeyImg.y = this.room2_character_north.y+75;
               this.room2_E_KeyImg.alpha = 1.0;
               if(this.room2_key_E.isDown) {
-                console.log("To room2 activity")
-                roomProgress += 1;
+                  if(roomProgress <= 2100)
+                        roomProgress = 2100;
                 this.scene.start("BuildBlock_Act1");
               }
             }

--- a/courseFinancialIntro.js
+++ b/courseFinancialIntro.js
@@ -6,12 +6,6 @@ class courseFinancialIntro extends Phaser.Scene {
         this.activatedQuiz = false;
         this.unlocked = false;
         this.paperMoveable = false;
-        this.activityOneOpened = false;
-        this.activityTwoOpened = false;
-        this.activityThreeOpened = false;
-        this.activityFourOpened = false;
-        this.activityFiveOpened = false;
-        this.activitySixOpened = false;
         this.helpOpen = false;
         this.holeOpened = false;
         this.counter = 0;
@@ -24,9 +18,6 @@ class courseFinancialIntro extends Phaser.Scene {
 
     //when scene is created
     create() {
-
-
-
         this.createImages();
         this.setAlphas();
         this.setDepths();
@@ -40,9 +31,6 @@ class courseFinancialIntro extends Phaser.Scene {
     update(delta) {
         //TEMPORARY FOR TESTING
         //vvvvvvvvvvvvvvvvvvv//
-        if (this.key_H.isDown) {
-            this.helpMenu();
-        }
 
         if (this.activityOneOpened) {
             this.checkNextPage();
@@ -55,12 +43,7 @@ class courseFinancialIntro extends Phaser.Scene {
         }
 
         if (this.key_U.isDown && this.unlocked == false) {
-            activity1Locked = false;
-            activity2Locked = false;
-            activity3Locked = false;
-            activity4Locked = false;
-            activity5Locked = false;
-            activity6Locked = false;
+            roomProgress = 1030;
             activity6Complete = true;
             this.unlocked = true;
         }
@@ -185,7 +168,7 @@ class courseFinancialIntro extends Phaser.Scene {
     createImages() {
         this.e_pressed = false;
         this.papers_moved = false;
-	this.returnDoor = this.add.image(113, 385, 'returnDoor');
+	    this.returnDoor = this.add.image(113, 385, 'returnDoor');
         this.background = this.add.image(768, 432, 'one_lesson_BG');
         this.character_north = this.add.image(768, 432, 'character_north');
         this.character_east = this.add.image(768, 432, 'character_east');
@@ -220,7 +203,6 @@ class courseFinancialIntro extends Phaser.Scene {
         this.help_menu = this.add.image(768, 432, 'help_menu');
         this.hole = this.add.image(768, 432, 'hole');
         this.congrats = this.add.image(810, 400, 'congrats');
-
         this.rightArrow = this.add.image(1000, 650, 'rightArrow');
         this.leftArrow = this.add.image(600, 650, 'rightArrow');
         this.placements0 = this.add.image(240, 800, 'correctPlacements0');
@@ -246,7 +228,7 @@ class courseFinancialIntro extends Phaser.Scene {
         this.leftArrow.alpha = 0;
         this.rightArrow.alpha = 0;
         this.congrats.alpha = 0;
-	this.returnDoor.alpha = 1;
+	    this.returnDoor.alpha = 1;
     }
 
     /* setDepths
@@ -276,7 +258,7 @@ class courseFinancialIntro extends Phaser.Scene {
         this.notebook.setDepth(100);
         this.help_menu.setDepth(100);
         this.hole.setDepth(1);
-	this.returnDoor.setDepth(1);
+	    this.returnDoor.setDepth(1);
     }
 
     /* setScales
@@ -304,7 +286,7 @@ class courseFinancialIntro extends Phaser.Scene {
         this.hole.setScale(0.75);
         this.leftArrow.setScale(.2);
         this.rightArrow.setScale(.2);
-	      this.returnDoor.setScale(1.5);
+	    this.returnDoor.setScale(1.5);
     }
 
     /* setRotations
@@ -319,7 +301,7 @@ class courseFinancialIntro extends Phaser.Scene {
         this.cardboard_box_2.rotation = 0;
         this.cardboard_box_3.rotation = 0;
         this.leftArrow.setRotation(3.14);
-	      this.returnDoor.angle = 270;
+	    this.returnDoor.angle = 270;
     }
 
     /* createInteractionZones
@@ -437,14 +419,13 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.y = this.character_north.y-75;
             this.E_KeyImg.alpha = 1.0;
             if (this.key_E.isDown) {
+                if(roomProgress <= 1005)
+                    roomProgress = 1005;
+
                 this.activity1A.alpha = 1.0;
                 this.resetArrows();
                 this.characterMoveable = false;
                 this.checkActivityOpened(true, false, false, false, false, false);
-                activity2Locked = false;
-
-                //COME BACK AND CHANGE THIS LATER
-                activity6Complete = true;
             }
 
         } else if(Phaser.Geom.Rectangle.ContainsPoint(this.middle_info, this.character_north)) {
@@ -452,12 +433,8 @@ class courseFinancialIntro extends Phaser.Scene {
                 this.E_KeyImg.x = this.character_north.x;
                 this.E_KeyImg.y = this.character_north.y + 75;
                 this.E_KeyImg.alpha = 1.0;
-
                 if(this.key_E.isDown) {
-		    // Normal sequence: roomProgress was 0 and is going to 1.
-		    // BUT
-		    //   if coming back from further on, the max remembers there.
-		    roomProgress = Math.max(2,roomProgress);
+                    roomProgress = 2000;
                     this.scene.start("Building_Blocks");
                 }
             }
@@ -466,26 +443,34 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.x = this.character_north.x;
             this.E_KeyImg.y = this.character_north.y+75;
             this.E_KeyImg.alpha = 1.0;
-            if (this.key_E.isDown && activity2Locked == false) {
+            if (this.key_E.isDown && roomProgress >= 1005) {
+                if(roomProgress <= 1010)
+                    roomProgress = 1010;
+
                 this.activity2.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, true, false, false, false, false);
-                activity3Locked = false;
-            } else if (this.key_E.isDown && activity2Locked == true) {
+
+            } else if (this.key_E.isDown && roomProgress < 1005) {
                 this.activityLocked.alpha = 1.0;
                 this.characterMoveable = false;
             }
 
         } else if (Phaser.Geom.Rectangle.ContainsPoint(this.top_mid_info, this.character_north)) {
+            console.log(roomProgress);
             this.E_KeyImg.x = this.character_north.x;
             this.E_KeyImg.y = this.character_north.y-75;
             this.E_KeyImg.alpha = 1.0;
-            if (this.key_E.isDown && activity3Locked == false) {
+            if (this.key_E.isDown && roomProgress >= 1010) {
+                if(roomProgress <= 1015)
+                    roomProgress = 1015;
+
                 this.activity3A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, true, false, false, false);
-                activity4Locked = false;
-            } else if (this.key_E.isDown && activity3Locked == true){
+
+                
+            } else if (this.key_E.isDown && roomProgress < 1010){
                 this.activityLocked.alpha = 1.0;
                 this.characterMoveable = false;
             }
@@ -494,12 +479,15 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.x = this.character_north.x;
             this.E_KeyImg.y = this.character_north.y+75;
             this.E_KeyImg.alpha = 1.0;
-            if (this.key_E.isDown && activity4Locked == false) {
+            if (this.key_E.isDown && roomProgress >= 1015) {
+                if(roomProgress <= 1020)
+                    roomProgress = 1020;
+                
                 this.activity4.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, false, true, false, false);
-                activity5Locked = false;
-            } else if (this.key_E.isDown && activity4Locked == true){
+
+            } else if (this.key_E.isDown && roomProgress < 1015){
                 this.activityLocked.alpha = 1.0;
                 this.characterMoveable = false;
             }
@@ -510,12 +498,15 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.y = this.character_north.y-75;
 
             this.E_KeyImg.alpha = 1.0;
-            if (this.key_E.isDown && activity5Locked == false) {
+            if (this.key_E.isDown && roomProgress >= 1020) {
+                if(roomProgress <= 1025)
+                    roomProgress = 1025;
+
                 this.activity5A.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, false, false, true, false);
-                activity6Locked = false;
-            } else if (this.key_E.isDown && activity5Locked == true){
+
+            } else if (this.key_E.isDown && roomProgress < 1020){
                 this.activityLocked.alpha = 1.0;
                 this.characterMoveable = false;
             }
@@ -524,12 +515,15 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.x = this.character_north.x;
             this.E_KeyImg.y = this.character_north.y+75;
             this.E_KeyImg.alpha = 1.0;
-            if (this.key_E.isDown && activity6Locked == false) {
+            if (this.key_E.isDown && roomProgress >= 1025) {
+                if(roomProgress <= 1030)
+                    roomProgress = 1030;
+
                 this.activity6.alpha = 1.0;
                 this.resetArrows();
                 this.checkActivityOpened(false, false, false, false, false, true);
-                activity6Complete = true;
-            } else if (this.key_E.isDown && activity6Locked == true){
+
+            } else if (this.key_E.isDown && roomProgress < 1025){
                 this.activityLocked.alpha = 1.0;
                 this.characterMoveable = false;
             }
@@ -538,9 +532,10 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.x = this.character_north.x+75;
             this.E_KeyImg.y = this.character_north.y;
             this.E_KeyImg.alpha = 1.0;
-            if (this.key_E.isDown && activity6Complete == true) {
+            if (this.key_E.isDown && roomProgress >= 1030) {
+                roomProgress = 1100;
                 this.quizActive = true;
-            } else if (this.key_E.isDown && activity6Complete == false){
+            } else if (this.key_E.isDown && roomProgress < 1030){
                 this.activityLocked.alpha = 1.0;
             }
         } else if (Phaser.Geom.Rectangle.ContainsPoint(this.exitDoor, this.character_north)){
@@ -548,7 +543,7 @@ class courseFinancialIntro extends Phaser.Scene {
             this.E_KeyImg.y = this.character_north.y;
             this.E_KeyImg.alpha = 1.0;
             if (this.key_E.isDown) {
-		this.scene.start("room_Zero");
+		    this.scene.start("TAG_Intro");
             }
         } else {
             this.hideActivities();
@@ -729,7 +724,7 @@ class courseFinancialIntro extends Phaser.Scene {
         this.hole.setVisible(false);
         this.paper_stack.setVisible(true);
 
-	this.returnDoor.x -= 40;
+	    this.returnDoor.x -= 40;
         this.paperMoveable = true;
         this.paperCount = 1;
         this.loadQuizImages();

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ var config = {
   scene: [tagIntro, courseFinancialIntro, buildingBlocks, buildBlockAct1, accountEqn, accountEqnAct, winners_room]
 
 };
+
 var quizActive = false;
 var activity1Locked = false;
 var activity2Locked = true;

--- a/tagIntro.js
+++ b/tagIntro.js
@@ -9,7 +9,7 @@ class tagIntro extends Phaser.Scene {
     this.paperMoveable = false;
     this.activityOneOpened = false;
     this.helpOpen = false;
-
+    
   }
   //load assets in preload()
 
@@ -258,24 +258,10 @@ Info Panels like these contain important information and lessons that help you p
 			if(this.key_E.isDown){
 			    // Normal sequence: roomProgress was 0 and is going to 1.
 			    // BUT
-			    //   if coming back from further on, the max remembers there.
-			    roomProgress = Math.max(1,roomProgress);
-			    if (roomProgress == 0) {
-				this.debugText = this.add.text(1200, 30, "roomProgress=0");
-			    }
-			    else if (roomProgress == 1) {
-				this.debugText = this.add.text(1200, 30, "roomProgress=1");
-			    }
-			    else {
-				this.debugText = this.add.text(1200, 30, "roomProgress=??");
-			    }
-			    this.debugText.setColor('black');
-			    this.debugText.setFont('bold 20px Arial');
-			    this.debugText.setVisible(true);
-
-			    this.scene.start("Course_Fin_Intro");
-
-			}
+          //   if coming back from further on, the max remembers there.
+          roomProgress += 1000;
+          this.scene.start("Course_Fin_Intro");
+      }
 			this.E_KeyImg.x = this.character_north.x;
 			this.E_KeyImg.y = this.character_north.y-75;
 			this.E_KeyImg.alpha = 1.0;


### PR DESCRIPTION
tagIntro: 0-1000

courseFinancialIntro: 1000-2000 (each panel is 5, ranging from 1000-1030, and the activity starts at 1030 and makes the roomProgress variable equal 1100).

buildingBlocks: 2000-3000 (each panel is 5, ranging from 2000-2030, and the puzzle room (buildingBlockAct1) opens at 2030 and make the roomProgress variable 2100 when you enter the puzzle room)

accountEqn: 3000-4000 (each panel is 5, ranging from 3000-3025. The hole become visible when the roomProgress variable is 3025).

Once a new rooms are added the roomProgress variable will continue to increase.




