### PR TITLE
only one panel was overlapping, all work now.

### DIFF
--- a/courseIntro.js
+++ b/courseIntro.js
@@ -481,7 +481,7 @@ class courseIntro extends Phaser.Scene {
             if (this.key_E.isDown) {
                 if(roomProgress <= 1005)
                     roomProgress = 1005;
-
+                    if(this.activity1B.alpha == 1) this.activity1B.alpha = 0;
                 this.activity1A.alpha = 1.0;
                 this.resetArrows();
                 this.characterMoveable = false;


### PR DESCRIPTION
fixed with an "if" statement before it sets the alpha after the E is pressed. still couldn't figure out why the second page was displaying on that one panel specifically, so if the issue arises again, the "if" statement patch could work again or it might be a bandage to a bigger issue that needs to be figured out.